### PR TITLE
Correct undeclared function and test failures

### DIFF
--- a/lib/server.c
+++ b/lib/server.c
@@ -87,7 +87,7 @@ int fuzi_q_server(fuzi_q_mode_enum fuzz_mode, picoquic_quic_config_t* config, ui
     }
 #endif
     if (ret == 0) {
-        fuzi_q_ctx.quic = picoquic_create_and_configure(config, picoquic_h09_server_callback, &picoquic_file_param, current_time, NULL);
+fuzi_q_ctx.quic = picoquic_create_and_configure(config, NULL, &picoquic_file_param, current_time, NULL);
         if (fuzi_q_ctx.quic == NULL) {
             ret = -1;
         }

--- a/lib/server.c
+++ b/lib/server.c
@@ -87,7 +87,7 @@ int fuzi_q_server(fuzi_q_mode_enum fuzz_mode, picoquic_quic_config_t* config, ui
     }
 #endif
     if (ret == 0) {
-        fuzi_q_ctx.quic = picoquic_create_and_configure(config, picoquic_demo_server_callback, &picoquic_file_param, current_time, NULL);
+        fuzi_q_ctx.quic = picoquic_create_and_configure(config, picoquic_h09_server_callback, &picoquic_file_param, current_time, NULL);
         if (fuzi_q_ctx.quic == NULL) {
             ret = -1;
         }

--- a/tests/basic_test.c
+++ b/tests/basic_test.c
@@ -496,7 +496,7 @@ int fuzi_q_set_test_server_ctx(fuzi_q_test_config_t* test_config, fuzi_q_ctx_t* 
         }
     }
 
-    fuzi_q_ctx->quic = picoquic_create_and_configure(&config, picoquic_h09_server_callback, NULL, test_config->simulated_time,
+fuzi_q_ctx->quic = picoquic_create_and_configure(&config, NULL, NULL, test_config->simulated_time,
         &test_config->simulated_time);
     if (fuzi_q_ctx->quic == NULL) {
         ret = -1;

--- a/tests/basic_test.c
+++ b/tests/basic_test.c
@@ -496,7 +496,7 @@ int fuzi_q_set_test_server_ctx(fuzi_q_test_config_t* test_config, fuzi_q_ctx_t* 
         }
     }
 
-    fuzi_q_ctx->quic = picoquic_create_and_configure(&config, picoquic_demo_server_callback, NULL, test_config->simulated_time,
+    fuzi_q_ctx->quic = picoquic_create_and_configure(&config, picoquic_h09_server_callback, NULL, test_config->simulated_time,
         &test_config->simulated_time);
     if (fuzi_q_ctx->quic == NULL) {
         ret = -1;


### PR DESCRIPTION
Replaced `picoquic_demo_server_callback` with `picoquic_h09_server_callback` in `lib/server.c` and `tests/basic_test.c` to resolve a compilation error.
```
/root/fuzi_q/lib/server.c:90:65: error: ‘picoquic_demo_server_callback’ undeclared (first use in this function); did you mean ‘picoquic_h09_server_callback’?
   90 |         fuzi_q_ctx.quic = picoquic_create_and_configure(config, picoquic_demo_server_callback, &picoquic_file_param, current_time, NULL);
      |                                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                 picoquic_h09_server_callback
/root/fuzi_q/lib/server.c:90:65: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [CMakeFiles/fuzy_q_core.dir/build.make:121: CMakeFiles/fuzy_q_core.dir/lib/server.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:97: CMakeFiles/fuzy_q_core.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
root@ubuntu:~/fuzi_q#
root@ubuntu:~/fuzi_q# vim /root/fuzi_q/lib/server.c
root@ubuntu:~/fuzi_q# make
[  7%] Building C object CMakeFiles/fuzy_q_core.dir/lib/server.c.o
[ 15%] Building C object CMakeFiles/fuzy_q_core.dir/lib/context.c.o
[ 23%] Linking C static library libfuzy_q_core.a
[ 46%] Built target fuzy_q_core
[ 53%] Building C object CMakeFiles/fuzi_q_tests.dir/tests/basic_test.c.o
/root/fuzi_q/tests/basic_test.c: In function ‘fuzi_q_set_test_server_ctx’:
/root/fuzi_q/tests/basic_test.c:499:63: error: ‘picoquic_demo_server_callback’ undeclared (first use in this function); did you mean ‘picoquic_h09_server_callback’?
  499 |     fuzi_q_ctx->quic = picoquic_create_and_configure(&config, picoquic_demo_server_callback, NULL, test_config->simulated_time,
      |                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                               picoquic_h09_server_callback
/root/fuzi_q/tests/basic_test.c:499:63: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [CMakeFiles/fuzi_q_tests.dir/build.make:79: CMakeFiles/fuzi_q_tests.dir/tests/basic_test.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:129: CMakeFiles/fuzi_q_tests.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
root@ubuntu:~/fuzi_q# vim /root/fuzi_q/tests/basic_test.c

```